### PR TITLE
Properly export `guildId` to be accessible by event schema

### DIFF
--- a/commands/event.js
+++ b/commands/event.js
@@ -92,7 +92,7 @@ module.exports = {
         // Execute /event add
         } else if (interaction.options.getSubcommand() === 'add') {
             // Make the server ID accessible by the event schema
-            global.guildId = interaction.guildId;
+            module.exports.guildId = interaction.guildId;
 
             // Dependencies
             const Discord = require('discord.js');
@@ -285,7 +285,7 @@ module.exports = {
         } else if (interaction.options.getSubcommand() === 'reschedule') {
 
             // Make the server ID accessible by the event schema
-            global.guildId = interaction.guildId;
+            module.exports.guildId = interaction.guildId;
 
             // Dependencies
             const Discord = require('discord.js');
@@ -335,7 +335,7 @@ module.exports = {
         } else if (interaction.options.getSubcommand() === 'cancel') {
 
             // Make the server ID accessible by the event schema
-            global.guildId = interaction.guildId;
+            module.exports.guildId = interaction.guildId;
 
             // Dependencies
             const Discord = require('discord.js');

--- a/config/event-schema.js
+++ b/config/event-schema.js
@@ -1,3 +1,5 @@
+const eventCommand = require('../commands/event');
+
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
@@ -7,7 +9,7 @@ const eventSchema = new Schema({
     eventEmoji: String,
     eventMessageId: String,
     eventRoleId: String
-}, { collection: guildId });
+}, { collection: eventCommand.guildId });
 
 const Event = mongoose.model('event', eventSchema);
 


### PR DESCRIPTION
> `ReferenceError: guildId is not defined`

`global` was a quick fix, now I'll just export `guildId`.